### PR TITLE
Fix missing evaluation of install package/gem choice

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,8 @@ fixtures:
     "monitor": "git://github.com/example42/puppet-monitor.git"
     "firewall": "git://github.com/example42/puppet-firewall.git"
     "iptables": "git://github.com/example42/puppet-iptables.git"
-    "concat": "git://github.com/puppetlabs/puppetlabs-concat.git"
+    "stdlib":   "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "concat":   "git://github.com/puppetlabs/puppetlabs-concat.git"
   symlinks:
     "vagrant": "#{source_dir}"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -176,6 +176,7 @@
 #
 class vagrant (
   $my_class            = params_lookup( 'my_class' ),
+  $install             = params_lookup( 'install' ),
   $source              = params_lookup( 'source' ),
   $source_dir          = params_lookup( 'source_dir' ),
   $source_dir_purge    = params_lookup( 'source_dir_purge' ),

--- a/spec/classes/vagrant_install_spec.rb
+++ b/spec/classes/vagrant_install_spec.rb
@@ -1,0 +1,17 @@
+require "#{File.join(File.dirname(__FILE__),'..','spec_helper.rb')}"
+
+describe 'vagrant::install' do
+
+  let(:title) { 'vagrant::install' }
+  let(:node) { 'rspec.example42.com' }
+
+  describe 'Test installation as a gem' do
+    let(:facts) { { :ipaddress => '10.42.42.42', :vagrant_install => 'gem' } }
+    it { should contain_package('vagrant').with_provider('gem') }
+  end
+
+  describe 'Test installation as a package' do
+    let(:facts) { { :ipaddress => '10.42.42.42', :vagrant_install => 'package' } }
+    it { should contain_package('vagrant').without_provider('gem') }
+  end
+end

--- a/spec/classes/vagrant_spec.rb
+++ b/spec/classes/vagrant_spec.rb
@@ -40,12 +40,10 @@ describe 'vagrant' do
     let(:params) { {:template => "vagrant/spec.erb" , :options => { 'opt_a' => 'value_a' } , :config_file => '/etc/vagrant.conf' } }
 
     it 'should generate a valid template' do
-      content = catalogue.resource('file', 'vagrant.conf').send(:parameters)[:content]
-      content.should match "fqdn: rspec.example42.com"
+      should contain_file('vagrant.conf').with_content(/fqdn: rspec.example42.com/)
     end
     it 'should generate a template that uses custom options' do
-      content = catalogue.resource('file', 'vagrant.conf').send(:parameters)[:content]
-      content.should match "value_a"
+      should contain_file('vagrant.conf').with_content(/value_a/)
     end
 
   end
@@ -54,24 +52,20 @@ describe 'vagrant' do
     let(:params) { {:source => "puppet://modules/vagrant/spec" , :source_dir => "puppet://modules/vagrant/dir/spec" , :source_dir_purge => true , :config_file => '/etc/vagrant.conf' , :config_dir => '/etc/vagrant/' } }
 
     it 'should request a valid source ' do
-      content = catalogue.resource('file', 'vagrant.conf').send(:parameters)[:source]
-      content.should == "puppet://modules/vagrant/spec"
+      should contain_file('vagrant.conf').with_source('puppet://modules/vagrant/spec')
     end
     it 'should request a valid source dir' do
-      content = catalogue.resource('file', 'vagrant.dir').send(:parameters)[:source]
-      content.should == "puppet://modules/vagrant/dir/spec"
+      should contain_file('vagrant.dir').with_source('puppet://modules/vagrant/dir/spec')
     end
     it 'should purge source dir if source_dir_purge is true' do
-      content = catalogue.resource('file', 'vagrant.dir').send(:parameters)[:purge]
-      content.should == true
+      should contain_file('vagrant.dir').with_purge('true')
     end
   end
 
   describe 'Test customizations - custom class' do
     let(:params) { {:my_class => "vagrant::spec" , :config_file => '/etc/vagrant.conf' } }
     it 'should automatically include a custom class' do
-      content = catalogue.resource('file', 'vagrant.conf').send(:parameters)[:content]
-      content.should match "fqdn: rspec.example42.com"
+      should contain_file('vagrant.conf').with_content(/fqdn: rspec.example42.com/)
     end
   end
 
@@ -79,8 +73,7 @@ describe 'vagrant' do
     let(:params) { {:puppi => true, :puppi_helper => "myhelper"} }
 
     it 'should generate a puppi::ze define' do
-      content = catalogue.resource('puppi::ze', 'vagrant').send(:parameters)[:helper]
-      content.should == "myhelper"
+      should contain_puppi__ze('vagrant').with_helper('myhelper')
     end
   end
 


### PR DESCRIPTION
The variable `$vagrant::install` was missing in the `init.pp` file, resulting in `install.pp` always falling to `gem` install.

This patch fixes that and added some tests.
